### PR TITLE
feat: Reduces critical path latency by caching builder info in runtime memory

### DIFF
--- a/services/api/service.go
+++ b/services/api/service.go
@@ -170,7 +170,7 @@ type blockSimResult struct {
 	blockValue           *uint256.Int
 	optimisticSubmission bool
 	requestErr           error
-	validationErr        error ``
+	validationErr        error
 }
 
 // RelayAPI represents a single Relay instance

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1764,7 +1764,6 @@ func (api *RelayAPI) checkSubmissionSlotDetails(w http.ResponseWriter, log *logr
 					return false
 				}
 				if !isBuilderRegistered {
-					// TODO: Implement caching strategy for builder registration status
 					api.RespondError(w, http.StatusBadRequest, "Builder pubkey is not registered under mev-commit")
 					return false
 				}

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1774,9 +1774,8 @@ func (api *RelayAPI) checkSubmissionSlotDetails(w http.ResponseWriter, log *logr
 					return false
 				}
 			} else if !builderCacheEntry.mevCommitOptInStatus {
-					api.RespondError(w, http.StatusBadRequest, "Builder pubkey is not opted into mev-commit")
-					return false
-				}
+				api.RespondError(w, http.StatusBadRequest, "Builder pubkey is not opted into mev-commit")
+				return false
 			}
 		}
 		duration := time.Since(start)

--- a/services/api/service.go
+++ b/services/api/service.go
@@ -1757,11 +1757,6 @@ func (api *RelayAPI) checkSubmissionSlotDetails(w http.ResponseWriter, log *logr
 		if duty.IsMevCommitValidator {
 			builderCacheEntry, ok := api.blockBuildersCache[submission.BidTrace.BuilderPubkey.String()]
 			if !ok {
-				log.Info("builder not found in cache")
-				api.RespondError(w, http.StatusBadRequest, "builder not found in cache")
-				return false
-			}
-			if !ok {
 				isBuilderRegistered, err := api.datastore.IsMevCommitBlockBuilder(common.NewPubkeyHex(submission.BidTrace.BuilderPubkey.String()))
 				if err != nil {
 					log.WithError(err).Error("Failed to check builder registration")

--- a/services/api/service_test.go
+++ b/services/api/service_test.go
@@ -1051,6 +1051,7 @@ func TestCheckBuilderEntry(t *testing.T) {
 				status: common.BuilderStatus{
 					IsHighPrio: true,
 				},
+				mevCommitOptInStatus: true,
 			},
 			pk:       builderPubkey,
 			expectOk: true,
@@ -1090,8 +1091,11 @@ func TestCheckBuilderEntry(t *testing.T) {
 			w := httptest.NewRecorder()
 			logger := logrus.New()
 			log := logrus.NewEntry(logger)
-			_, ok := backend.relay.checkBuilderEntry(w, log, builderPubkey)
+			entry, ok := backend.relay.checkBuilderEntry(w, log, builderPubkey)
 			require.Equal(t, tc.expectOk, ok)
+			if ok {
+				require.Equal(t, tc.entry.mevCommitOptInStatus, entry.mevCommitOptInStatus)
+			}
 		})
 	}
 }

--- a/services/api/service_test.go
+++ b/services/api/service_test.go
@@ -904,6 +904,9 @@ func TestCheckSubmissionPayloadAttrs(t *testing.T) {
 			backend.relay.payloadAttributesLock.RLock()
 			backend.relay.payloadAttributes[getPayloadAttributesKey(testParentHash, testSlot)] = tc.attrs
 			backend.relay.payloadAttributesLock.RUnlock()
+			backend.relay.blockBuildersCache[testBuilderPubkey] = &blockBuilderCacheEntry{
+				mevCommitOptInStatus: true,
+			}
 
 			w := httptest.NewRecorder()
 			logger := logrus.New()
@@ -917,10 +920,13 @@ func TestCheckSubmissionPayloadAttrs(t *testing.T) {
 }
 
 func TestCheckSubmissionSlotDetails(t *testing.T) {
+	builderPubkey, err := utils.HexToPubkey(testBuilderPubkey)
+	require.NoError(t, err)
 	cases := []struct {
-		description string
-		payload     *common.VersionedSubmitBlockRequest
-		expectOk    bool
+		description          string
+		payload              *common.VersionedSubmitBlockRequest
+		expectOk             bool
+		mevCommitOptInStatus bool
 	}{
 		{
 			description: "success",
@@ -932,12 +938,14 @@ func TestCheckSubmissionSlotDetails(t *testing.T) {
 							Timestamp: testSlot * common.SecondsPerSlot,
 						},
 						Message: &builderApiV1.BidTrace{
-							Slot: testSlot,
+							Slot:          testSlot,
+							BuilderPubkey: builderPubkey,
 						},
 					},
 				},
 			},
-			expectOk: true,
+			expectOk:             true,
+			mevCommitOptInStatus: true,
 		},
 		{
 			description: "non_capella_slot",
@@ -1027,6 +1035,10 @@ func TestCheckSubmissionSlotDetails(t *testing.T) {
 						Pubkey: validatorPubKey,
 					},
 				},
+				IsMevCommitValidator: tc.mevCommitOptInStatus,
+			}
+			backend.relay.blockBuildersCache[testBuilderPubkey] = &blockBuilderCacheEntry{
+				mevCommitOptInStatus: tc.mevCommitOptInStatus,
 			}
 			ok := backend.relay.checkSubmissionSlotDetails(w, log, headSlot, tc.payload, submission)
 			require.Equal(t, tc.expectOk, ok)


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->

## ⛱ Motivation and Context
* To improve performance, we cache common builder identities every slot with information about their opt-in status in mev-commit.
<!--- Why is this change required? What problem does it solve? -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [ ] `make lint`
* [ ] `make test-race`
* [ ] `go mod tidy`
* [ ] I have seen and agree to `CONTRIBUTING.md`
